### PR TITLE
add retries to watchdog to workaround get watchdog failure in 202211

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/watchdog.py
@@ -28,6 +28,18 @@ import time
 
 from sonic_platform_base.watchdog_base import WatchdogBase
 
+try:
+    from sonic_py_common.logger import Logger
+except ImportError as e:
+    raise ImportError (str(e) + "- required module not found")
+
+# Global logger class instance
+logger = Logger()
+
+# watchdog retries workaround for device missing after first install from ONIE on 24xx/2700 switches
+RETRIES = 10
+DELAY_BETWEEN_RETRIES = 1
+
 """ ioctl constants """
 IO_WRITE = 0x40000000
 IO_READ = 0x80000000
@@ -287,9 +299,17 @@ def get_watchdog():
 
     watchdog_main_device_name = None
 
-    for device in os.listdir("/dev/"):
-        if device.startswith("watchdog") and is_mlnx_wd_main(device):
-            watchdog_main_device_name = device
+    found = False
+    for iteration in range(RETRIES):
+        for device in os.listdir("/dev/"):
+            if device.startswith("watchdog") and is_mlnx_wd_main(device):
+                watchdog_main_device_name = device
+                found = True
+                logger.log_notice('Found watchdog device {} after {} retries with delay {}'.format(device, iteration, DELAY_BETWEEN_RETRIES))
+        if found:
+            break
+        logger.log_notice('watchdog device not fount, iteration {}, sleeping {}'.format(iteration, DELAY_BETWEEN_RETRIES))
+        time.sleep(DELAY_BETWEEN_RETRIES)
 
     if watchdog_main_device_name is None:
         return None


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
resolve get watchdog failure upon first installation from ONIE

#### How I did it
add retries and delay between them

#### How to verify it
install image from ONIE and verify no get watchdog failure in watchdog-control service status

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

