### PR TITLE
fix low polarity wrong value for hw_reset deassert and seek(0) before reading sysfs

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -279,8 +279,8 @@ class ModulesMgmtTask(threading.Thread):
                     module_fd_path = module_obj.module_power_good_fd_path
                 self.fds_events_count_dict[module_obj.port_num][fd_name] += 1
                 try:
-                    val = module_fd.read()
                     module_fd.seek(0)
+                    val = module_fd.read()
                     logger.log_info("dynamic detection got module_obj {} with port {} from fd number {} path {} val {} count {}"
                                   .format(module_obj, module_obj.port_num, fd, module_fd_path
                                           , val, self.fds_events_count_dict[module_obj.port_num]))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -450,8 +450,9 @@ class ModulesMgmtTask(threading.Thread):
                     utils.write_file(module_fd_indep_path_po, "1")
                 if os.path.isfile(module_fd_indep_path_r):
                     logger.log_info("powerOnModule resetting via {} for port {}".format(module_fd_indep_path_r, port))
-                    # echo 0 > /sys/module/sx_core/$asic/$module/hw_reset
-                    utils.write_file(module_fd_indep_path_r, "0")
+                    # de-assert hw_reset - low polarity. 1 for de-assert 0 for assert
+                    # echo 1 > /sys/module/sx_core/$asic/$module/hw_reset
+                    utils.write_file(module_fd_indep_path_r, "1")
                 self.add_port_to_wait_reset(module_sm_obj)
             except Exception as e:
                 logger.log_info("exception in powerOnModule {} for port {}".format(e, port))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix low polarity wrong value for hw_reset deassert as part of power_on_module state function
fix power_good sysfs that returns empty string upon cable plug out

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
send 1 to hw_reset sysfs instead of existing 0 value sent to deassert hw_reset after power_on when needed
move seek(0) of sysfs fd before reading the sysfs fd

#### How to verify it
run the code in manual test of plugged out cable when the switch it booted.
then plug in the cable after module detection is done and dynamic detection takes place listening to sysfs changes via poller
for optic CMIS cable CMIS it will not be powered on thus will go into power_on_module function with the above change here.
at the end of module detection for this new cable inserted, EEPROM should be available for reading (currently with 0 sent to hw_reset EEPROM is not available at the end)

make sure power_good sysfs is not empty anymore upon cable plug out - it should have value of 0 when the cable is out

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

