### PR TITLE
add fast reboot check and dont send dict to get_change_event after warm or fast reboot done

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/modules_mgmt.py
@@ -69,6 +69,7 @@ IS_INDEPENDENT_MODULE = 'is_independent_module'
 PROC_CMDLINE = "/proc/cmdline"
 CMDLINE_STR_TO_LOOK_FOR = 'SONIC_BOOT_TYPE='
 CMDLINE_VAL_TO_LOOK_FOR = 'fastfast'
+CMDLINE_VAL_TO_LOOK_FOR_FAST_REBOOT = 'fast-reboot'
 
 MAX_EEPROM_ERROR_RESET_RETRIES = 4
 
@@ -98,6 +99,7 @@ class ModulesMgmtTask(threading.Thread):
         self.setName("ModulesMgmtTask")
         self.register_hw_present_fds = []
         self.is_warm_reboot = False
+        self.is_fast_reboot = False
         self.port_control_dict = {}
 
     # SFPs state machine
@@ -161,7 +163,9 @@ class ModulesMgmtTask(threading.Thread):
             cmdline_dict[CMDLINE_STR_TO_LOOK_FOR] = proc_cmdline_str.split(CMDLINE_STR_TO_LOOK_FOR)[1]
         if CMDLINE_STR_TO_LOOK_FOR in cmdline_dict.keys():
             self.is_warm_reboot = cmdline_dict[CMDLINE_STR_TO_LOOK_FOR] == CMDLINE_VAL_TO_LOOK_FOR
-            logger.log_info(f"system was warm rebooted is_warm_reboot: {self.is_warm_reboot}")
+            self.is_fast_reboot = cmdline_dict[CMDLINE_STR_TO_LOOK_FOR] == CMDLINE_VAL_TO_LOOK_FOR_FAST_REBOOT
+            logger.log_info(f"system was warm or fast rebooted is_warm_reboot: {self.is_warm_reboot} is_fast_reboot:"
+                            f"{self.is_fast_reboot}")
         for port in range(num_of_ports):
             # check sysfs per port whether it's independent mode or legacy
             temp_module_sm = ModuleStateMachine(port_num=port, initial_state=STATE_HW_NOT_PRESENT
@@ -661,7 +665,8 @@ class ModulesMgmtTask(threading.Thread):
                     self.register_hw_present_fds.append(module_obj)
                 else:
                     port_status = '1'
-                self.sfp_changes_dict[str(module_obj.port_num + 1)] = port_status
+                if dynamic or (not self.is_warm_reboot and not self.is_fast_reboot):
+                    self.sfp_changes_dict[str(module_obj.port_num + 1)] = port_status
 
     def delete_ports_from_dict(self, dynamic=False):
         detection_method = 'dynamic' if dynamic else 'static'


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

